### PR TITLE
Register Run Study workflow on the default branch

### DIFF
--- a/.github/workflows/run-study.yaml
+++ b/.github/workflows/run-study.yaml
@@ -14,6 +14,11 @@ permissions:
 jobs:
   run-study:
     runs-on: ubuntu-latest
+    env:
+      # remotes::install_github() needs an API token; without one it falls
+      # back to its long-dead bundled PAT and every install fails. The
+      # default workflow token reads public repos fine.
+      GITHUB_PAT: ${{ github.token }}
     defaults:
       run:
         working-directory: study

--- a/.github/workflows/run-study.yaml
+++ b/.github/workflows/run-study.yaml
@@ -1,0 +1,55 @@
+name: Run Study
+
+# Self-contained demo study: the workflow bundle (public-only subset),
+# package pins, and run scripts are all vendored under study/, adapted from
+# Gilead-BioStats/AA-AA-000-0000@demo/gsm-datasim-load-single-snapshot.
+# Every dependency is a public repo, so no org PAT is required.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-study:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: study
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.4'
+          use-public-rspm: true
+
+      # rv sync against rproject.toml is the intended end-state install path;
+      # kept non-blocking (mirrors the source study repo) — the manifest.csv
+      # install below is the library the run actually uses.
+      - name: Set up rv
+        continue-on-error: true
+        uses: a2-ai/setup-rv@v1.0.0
+
+      - name: rv sync (non-blocking verification)
+        continue-on-error: true
+        timeout-minutes: 30
+        run: rv sync --config-file rproject.toml && echo "rv sync SUCCEEDED" || echo "::warning::rv sync incomplete - see step log"
+
+      - name: Install pinned environment from manifest.csv
+        run: Rscript scripts/01-install-environment.R
+
+      - name: Run workflows
+        run: Rscript scripts/03-run-workflows.R
+
+      - name: Upload outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: study-output
+          path: study/data/output
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## Why

`workflow_dispatch` only exposes workflows whose file exists on the **default branch** — the dispatch then executes with whatever `ref` is passed. The self-contained demo study (vendored `study/` bundle, public-only package pins, datasim-generated input, workr pipeline) lives on `workr-implementation`, but its workflow can't be triggered until this file is registered on `main`.

This PR adds exactly one file: `.github/workflows/run-study.yaml`.

## What the workflow does (when dispatched with `--ref workr-implementation`)

1. `rv sync` against `study/rproject.toml` (non-blocking verification path)
2. Installs the SHA-pinned environment from `study/manifest.csv` — public repos only, no org PAT required
3. Runs the full workflow bundle (mappings → metrics → reporting) via workr, with input generated by workr's gsm.datasim LoadData provider
4. Uploads a `study-output` artifact (workr-results.rds + run metadata)

The artifact is the interim data layer: `demo/fetch_run_results.R` (on `workr-implementation`) converts it into the CSVs the dashboard renders — no generated data is ever committed.

## How to trigger

- Dashboard → Runs tab → ▶ Run Study, or
- `gh workflow run run-study.yaml --ref workr-implementation`